### PR TITLE
Bytt navn på event_type fra behov til faktum_svar

### DIFF
--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/MediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/MediatorTest.kt
@@ -51,7 +51,7 @@ internal class MediatorTest {
     fun `ta imot svar`() {
         testRapid.sendTestMessage(meldingsfabrikk.nySøknadMelding())
         val uuid = UUID.fromString(testRapid.inspektør.message(0)["søknad_uuid"].asText())
-        assertEquals("behov", testRapid.inspektør.message(0)["@event_name"].asText())
+        assertEquals("faktum_svar", testRapid.inspektør.message(0)["@event_name"].asText())
 
         testRapid.sendTestMessage(
             meldingsfabrikk.besvarFaktum(
@@ -60,7 +60,7 @@ internal class MediatorTest {
                 FaktumSvar(2, "boolean", "true")
             )
         )
-        assertEquals("behov", testRapid.inspektør.field(1, "@event_name").asText())
+        assertEquals("faktum_svar", testRapid.inspektør.field(1, "@event_name").asText())
         assertEquals(true, grupperer.søknadprosess!!.id(1).svar())
 
         testRapid.sendTestMessage(meldingsfabrikk.besvarFaktum(uuid, FaktumSvar(3, "heltall", "2")))

--- a/model/src/main/kotlin/no/nav/dagpenger/model/marshalling/NavJsonBuilder.kt
+++ b/model/src/main/kotlin/no/nav/dagpenger/model/marshalling/NavJsonBuilder.kt
@@ -36,7 +36,7 @@ class NavJsonBuilder(søknadprosess: Søknadprosess, seksjonNavn: String, indeks
     fun resultat() = root
 
     override fun preVisit(søknad: Søknad, versjonId: Int, uuid: UUID) {
-        root.put("@event_name", "behov")
+        root.put("@event_name", "faktum_svar")
         root.put("@opprettet", "${LocalDateTime.now()}")
         root.put("@id", "${UUID.randomUUID()}")
         root.put("søknad_uuid", "$uuid")

--- a/model/src/test/kotlin/no/nav/dagpenger/model/unit/marshalling/NavJsonBuilderTest.kt
+++ b/model/src/test/kotlin/no/nav/dagpenger/model/unit/marshalling/NavJsonBuilderTest.kt
@@ -121,7 +121,7 @@ class NavJsonBuilderTest {
         avhengigeBehov: List<String>
     ) {
         val faktumOgBehovMap = faktumOgBehov.toMap()
-        assertEquals("behov", json["@event_name"].asText())
+        assertEquals("faktum_svar", json["@event_name"].asText())
         assertEquals("folkeregisterident", json["identer"][0]["type"].asText())
         assertEquals("12020052345", json["identer"][0]["id"].asText())
         assertTrue(json.has("@id"))


### PR DESCRIPTION
Det er ingen plasser pakken MÅ ha event-typen faktum_svar før den skal konsumeres av `dp-quiz`. Vi kan like gjerne ha riktig navn hele veien, så slipper vi å skrive om i løsningservicene.