### PR TITLE
Sjekk om personen faktisk har inntekt fra fangst og fiske

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/AvslagPåMinsteinntektOppsett.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/AvslagPåMinsteinntektOppsett.kt
@@ -27,7 +27,7 @@ internal object AvslagPåMinsteinntektOppsett {
 
     const val ønsketDato = 1
     const val virkningsdato = 4
-    const val fangstOgFisk = 5
+    const val fangstOgFiskInntektSiste36mnd = 5
     const val inntektSiste36mnd = 6
     const val inntektSiste12mnd = 7
     const val minsteinntektfaktor36mnd = 8
@@ -84,9 +84,9 @@ internal object AvslagPåMinsteinntektOppsett {
             VERSJON_ID,
             dato faktum "Ønsker dagpenger fra dato" id ønsketDato avhengerAv innsendtSøknadsId,
             maks dato "Virkningsdato" av ønsketDato og søknadstidspunkt id virkningsdato,
-            boolsk faktum "Driver med fangst og fisk" id fangstOgFisk avhengerAv innsendtSøknadsId,
-            inntekt faktum "Inntekt siste 36 mnd" id inntektSiste36mnd avhengerAv virkningsdato og fangstOgFisk,
-            inntekt faktum "Inntekt siste 12 mnd" id inntektSiste12mnd avhengerAv virkningsdato og fangstOgFisk,
+            boolsk faktum "Har hatt inntekt fra fangst og fisk siste 36 mnd" id fangstOgFiskInntektSiste36mnd avhengerAv virkningsdato,
+            inntekt faktum "Inntekt siste 36 mnd" id inntektSiste36mnd avhengerAv virkningsdato og fangstOgFiskInntektSiste36mnd,
+            inntekt faktum "Inntekt siste 12 mnd" id inntektSiste12mnd avhengerAv virkningsdato og fangstOgFiskInntektSiste36mnd,
             inntekt faktum "Grunnbeløp" id grunnbeløp avhengerAv virkningsdato,
             desimaltall faktum "Øvre faktor" id minsteinntektfaktor36mnd avhengerAv virkningsdato,
             desimaltall faktum "Nedre faktor" id minsteinntektfaktor12mnd avhengerAv virkningsdato,
@@ -109,7 +109,7 @@ internal object AvslagPåMinsteinntektOppsett {
             boolsk faktum "Har brukt opp forrige dagpengeperiode" id periodeOppbruktManuell avhengerAv harHattDagpengerSiste36mnd,
             boolsk faktum "Sykepenger siste 36 mnd" id sykepengerSiste36mnd avhengerAv virkningsdato,
             boolsk faktum "Svangerskapsrelaterte sykepenger" id svangerskapsrelaterteSykepengerManuell avhengerAv sykepengerSiste36mnd,
-            boolsk faktum "Fangst og fisk manuell" id fangstOgFiskManuell avhengerAv fangstOgFisk,
+            boolsk faktum "Fangst og fisk manuell" id fangstOgFiskManuell avhengerAv fangstOgFiskInntektSiste36mnd,
             boolsk faktum "Har hatt inntekt/trygdeperioder fra EØS" id eøsArbeid avhengerAv innsendtSøknadsId,
             boolsk faktum "EØS arbeid manuell" id eøsArbeidManuell avhengerAv eøsArbeid,
             boolsk faktum "Ugyldig dato manuell" id uhåndterbartVirkningsdatoManuell avhengerAv virkningsdato,
@@ -142,7 +142,7 @@ internal object AvslagPåMinsteinntektOppsett {
             mapOf(
                 ønsketDato to "ØnskerDagpengerFraDato",
                 virkningsdato to "Virkningstidspunkt",
-                fangstOgFisk to "FangstOgFiske",
+                fangstOgFiskInntektSiste36mnd to "FangstOgFiskeInntektSiste36mnd",
                 inntektSiste36mnd to "InntektSiste3År",
                 inntektSiste12mnd to "InntektSiste12Mnd",
                 minsteinntektfaktor36mnd to "ØvreTerskelFaktor",

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/ManuellBehandling.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/ManuellBehandling.kt
@@ -6,7 +6,7 @@ import no.nav.dagpenger.model.subsumsjon.hvisOppfyltManuell
 import no.nav.dagpenger.model.subsumsjon.minstEnAv
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.eøsArbeid
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.eøsArbeidManuell
-import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fangstOgFisk
+import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fangstOgFiskInntektSiste36mnd
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fangstOgFiskManuell
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fortsattRettKorona
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fortsattRettKoronaManuell
@@ -26,7 +26,7 @@ import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.virkn
 internal object ManuellBehandling {
 
     private val hattInntektFraFangstOgFisk = with(søknad) {
-        boolsk(fangstOgFisk) er true hvisOppfyltManuell (boolsk(fangstOgFiskManuell))
+        boolsk(fangstOgFiskInntektSiste36mnd) er true hvisOppfyltManuell (boolsk(fangstOgFiskManuell))
     }
 
     private val harArbeidetEøs = with(søknad) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/Seksjoner.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/Seksjoner.kt
@@ -7,7 +7,7 @@ import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.antal
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.behandlingsdato
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.eøsArbeid
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.eøsArbeidManuell
-import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fangstOgFisk
+import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fangstOgFiskInntektSiste36mnd
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fangstOgFiskManuell
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.flereArbeidsforholdManuell
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fortsattRettKorona
@@ -92,7 +92,6 @@ internal object Seksjoner {
             boolsk(verneplikt),
             boolsk(lærling),
             boolsk(eøsArbeid),
-            boolsk(fangstOgFisk),
             boolsk(kanJobbeDeltid),
             boolsk(helseTilAlleTyperJobb),
             boolsk(kanJobbeHvorSomHelst),
@@ -118,6 +117,14 @@ internal object Seksjoner {
             Rolle.nav,
             boolsk(harHattDagpengerSiste36mnd),
             boolsk(hattLukkedeSakerSiste8Uker),
+        )
+    }
+
+    private val inntektshistorikk = with(søknad) {
+        Seksjon(
+            "inntektshistorikk",
+            Rolle.nav,
+            boolsk(fangstOgFiskInntektSiste36mnd)
         )
     }
 
@@ -306,6 +313,7 @@ internal object Seksjoner {
             dataFraSøknad,
             arbeidsøkerPerioder,
             dagpengehistorikk,
+            inntektshistorikk,
             sykepengehistorikk,
             inntekter,
             inntektNesteKalendermåned,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/integration/AvslagPåMinsteinntektTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/integration/AvslagPåMinsteinntektTest.kt
@@ -16,7 +16,7 @@ import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.antallEndredeArbeidsforhold
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.behandlingsdato
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.eøsArbeid
-import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fangstOgFisk
+import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fangstOgFiskInntektSiste36mnd
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fortsattRettKorona
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.grunnbeløp
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste36mnd
@@ -98,7 +98,7 @@ internal class AvslagPåMinsteinntektTest {
             assertGjeldendeSeksjon("datafrasøknad")
             besvar(eøsArbeid, false)
             besvar(jobbetUtenforNorge, false)
-            besvar(fangstOgFisk, false)
+            besvar(fangstOgFiskInntektSiste36mnd, false)
             besvar(verneplikt, false)
             besvar(lærling, false)
             besvar(ønsketDato, 5.januar)
@@ -115,6 +115,9 @@ internal class AvslagPåMinsteinntektTest {
 
             assertGjeldendeSeksjon("inntektsrapporteringsperioder")
             besvar(inntektsrapporteringsperiodeTom, 10.januar)
+
+            assertGjeldendeSeksjon("inntektshistorikk")
+            besvar(fangstOgFiskInntektSiste36mnd, false)
 
             assertGjeldendeSeksjon("dagpengehistorikk")
             besvar(harHattDagpengerSiste36mnd, false)

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/soknad/RegeltreTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/soknad/RegeltreTest.kt
@@ -14,7 +14,7 @@ import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.antal
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.arenaFagsakId
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.behandlingsdato
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.eøsArbeid
-import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fangstOgFisk
+import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fangstOgFiskInntektSiste36mnd
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.fortsattRettKorona
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.grunnbeløp
 import no.nav.dagpenger.quiz.mediator.soknad.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste36mnd
@@ -99,7 +99,7 @@ internal class RegeltreTest {
             boolsk(eøsArbeid).besvar(false)
             boolsk(jobbetUtenforNorge).besvar(false)
 
-            boolsk(fangstOgFisk).besvar(false)
+            boolsk(fangstOgFiskInntektSiste36mnd).besvar(false)
 
             inntekt(grunnbeløp).besvar(100000.årlig)
             desimaltall(minsteinntektfaktor12mnd).besvar(1.5)
@@ -192,7 +192,7 @@ internal class RegeltreTest {
 
     @Test
     fun `Fangst og fisk skal manuelt behandles`() {
-        manglerInntekt.boolsk(fangstOgFisk).besvar(true)
+        manglerInntekt.boolsk(fangstOgFiskInntektSiste36mnd).besvar(true)
         assertNesteSeksjon("mulige inntekter fra fangst og fisk")
     }
 


### PR DESCRIPTION
I dag bruker vi svaret fra bruker. Vi kan like gjerne sjekke om personen faktisk har inntekt.

Har personen inntekt fra fangst og fiske så blir den regnet med. Er det
fortsatt avslag så blir det uansett avslag, med eller uten fangst og
fiske.

Er inntekt (+ fangst og fiske) over minsteinntekt så vil saken gå til
manuell vurdering.