### PR TITLE
Lagre ny søknad i 1 transaksjon mot databasen.

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/db/NySøknad.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/db/NySøknad.kt
@@ -22,12 +22,13 @@ import no.nav.dagpenger.quiz.mediator.db.PostgresDataSourceBuilder.dataSource
 import java.util.UUID
 
 class NySøknad(søknad: Søknad, private val type: Versjon.UserInterfaceType) : SøknadVisitor {
-    private var søknadId = 0
     private var internVersjonId = 0
     private var rootId = 0
     private var indeks = 0
     private val faktumList = mutableListOf<Faktum<*>>()
     private var personId: UUID? = null
+    private lateinit var søknadUUID: UUID
+    private val faktumParams = mutableListOf<List<Any>>()
 
     init {
         if (SøknadUuid(søknad).ikkeEksisterer()) {
@@ -53,28 +54,40 @@ class NySøknad(søknad: Søknad, private val type: Versjon.UserInterfaceType) :
 
     override fun preVisit(søknad: Søknad, prosessVersjon: Prosessversjon, uuid: UUID) {
         this.internVersjonId = hentInternId(prosessVersjon)
-        søknadId = using(sessionOf(dataSource)) { session ->
-            session.run(
-                queryOf( //language=PostgreSQL
-                    """
-                        INSERT INTO soknad(uuid, versjon_id, person_id, sesjon_type_id) 
-                        VALUES (:uuid, :versjon_id, :person_id, :sesjon_type_id) 
-                        RETURNING id
-                    """.trimIndent(),
-                    mapOf(
-                        "uuid" to uuid,
-                        "versjon_id" to internVersjonId,
-                        "person_id" to personId,
-                        "sesjon_type_id" to type.id
-                    )
-                ).map { it.int(1) }.asSingle
-            ) ?: throw IllegalArgumentException("failed to find søknadId")
-        }
+        this.søknadUUID = uuid
     }
 
     override fun visit(faktumId: FaktumId, rootId: Int, indeks: Int) {
         this.rootId = rootId
         this.indeks = indeks
+    }
+
+    override fun postVisit(søknad: Søknad, prosessVersjon: Prosessversjon, uuid: UUID) {
+        val faktumInsertStatement = //language=PostgreSQL
+            """INSERT INTO faktum_verdi
+                                (soknad_id, indeks, faktum_id)
+                            VALUES ((SELECT id FROM soknad WHERE uuid = ?), ?,
+                                    (SELECT id FROM faktum WHERE versjon_id = ? AND root_id = ?))""".trimMargin()
+
+        using(sessionOf(dataSource)) { session ->
+            session.transaction { transactionalSession ->
+                transactionalSession.run(
+                    queryOf( //language=PostgreSQL
+                        """
+                        INSERT INTO soknad(uuid, versjon_id, person_id, sesjon_type_id) 
+                        VALUES (:uuid, :versjon_id, :person_id, :sesjon_type_id) 
+                        """.trimIndent(),
+                        mapOf(
+                            "uuid" to søknadUUID,
+                            "versjon_id" to internVersjonId,
+                            "person_id" to personId,
+                            "sesjon_type_id" to type.id
+                        )
+                    ).asUpdate
+                )
+                transactionalSession.batchPreparedStatement(faktumInsertStatement, faktumParams)
+            }
+        }
     }
 
     override fun <R : Comparable<R>> visitUtenSvar(
@@ -130,20 +143,7 @@ class NySøknad(søknad: Søknad, private val type: Versjon.UserInterfaceType) :
 
     private fun skrivFaktumVerdi(faktum: Faktum<*>) {
         if (faktum in faktumList) return else faktumList.add(faktum)
-        using(sessionOf(dataSource)) { session ->
-            session.run(
-                queryOf( //language=PostgreSQL
-                    """INSERT INTO faktum_verdi
-                                (soknad_id, indeks, faktum_id)
-                            VALUES (?, ?,
-                                    (SELECT id FROM faktum WHERE versjon_id = ? AND root_id = ?))""".trimMargin(),
-                    søknadId,
-                    indeks,
-                    internVersjonId,
-                    rootId
-                ).asExecute
-            )
-        }
+        faktumParams.add(listOf(søknadUUID, indeks, internVersjonId, rootId))
     }
 
     private class SøknadUuid(søknad: Søknad) : SøknadVisitor {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
@@ -358,7 +358,11 @@ internal class SøknadRecordTest {
     private fun byggOriginalSøknadprosess() {
         FaktumTable(SøknadEksempel1.prototypeFakta1)
         søknadRecord = SøknadRecord()
-        originalSøknadprosess = søknadRecord.ny(UNG_PERSON_FNR_2018, Web, SøknadEksempel1.prosessVersjon)
+        try {
+            originalSøknadprosess = søknadRecord.ny(UNG_PERSON_FNR_2018, Web, SøknadEksempel1.prosessVersjon)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 
     private fun assertRecordCount(recordCount: Int, table: String) {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
@@ -358,11 +358,7 @@ internal class SøknadRecordTest {
     private fun byggOriginalSøknadprosess() {
         FaktumTable(SøknadEksempel1.prototypeFakta1)
         søknadRecord = SøknadRecord()
-        try {
-            originalSøknadprosess = søknadRecord.ny(UNG_PERSON_FNR_2018, Web, SøknadEksempel1.prosessVersjon)
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
+        originalSøknadprosess = søknadRecord.ny(UNG_PERSON_FNR_2018, Web, SøknadEksempel1.prosessVersjon)
     }
 
     private fun assertRecordCount(recordCount: Int, table: String) {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/NySøknadTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/NySøknadTest.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.quiz.mediator.meldinger
 
-import io.getunleash.FakeUnleash
 import no.nav.dagpenger.quiz.mediator.helpers.SøknadEksempel
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.intellij.lang.annotations.Language
@@ -20,9 +19,6 @@ internal class NySøknadTest {
     private companion object {
         private val testRapid = TestRapid()
         private val søknadPersistance = SøknadPersistenceFake()
-        private val unleash = FakeUnleash().also {
-            it.enableAll()
-        }
 
         init {
             AvslagPåMinsteinntektService(søknadPersistance, testRapid, SøknadEksempel.prosessVersjon)


### PR DESCRIPTION
Har opplevd at vi har klart å lagre søknad i `soknad` tabellen men feilet å lagre `faktum_verdi` som førte til en inkonsisten søknad.