### PR TITLE
Lag støtte for migrering

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/behovløsere/MigrerProsessService.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/behovløsere/MigrerProsessService.kt
@@ -1,0 +1,45 @@
+package no.nav.dagpenger.quiz.mediator.behovløsere
+
+import mu.KotlinLogging
+import mu.withLoggingContext
+import no.nav.dagpenger.quiz.mediator.db.SøknadPersistence
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.helse.rapids_rivers.River
+
+class MigrerProsessService(
+    rapidsConnection: RapidsConnection,
+    private val søknadPersistence: SøknadPersistence,
+) : River.PacketListener {
+    private companion object {
+        val logger = KotlinLogging.logger { }
+        val behov = "MigrerProsess"
+    }
+
+    init {
+        River(rapidsConnection).apply {
+            validate { it.demandValue("@event_name", "behov") }
+            validate { it.demandAll("@behov", listOf(behov)) }
+            validate { it.requireKey("søknad_uuid", behov) }
+            validate { it.forbid("@løsning") }
+        }.register(this)
+    }
+
+    override fun onPacket(packet: JsonMessage, context: MessageContext) {
+        val søknadId = packet.søknadUUID()
+
+        withLoggingContext("søknadId" to søknadId.toString()) {
+
+            val prosessversjon = søknadPersistence.migrer(søknadId)
+
+            packet["@løsning"] = mapOf(
+                behov to søknadId,
+                "NyVersjon" to prosessversjon.versjon
+            )
+
+            context.publish(packet.toJson())
+            logger.info { "Løser $behov" }
+        }
+    }
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/behovløsere/MigrerProsessService.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/behovløsere/MigrerProsessService.kt
@@ -21,7 +21,7 @@ class MigrerProsessService(
         River(rapidsConnection).apply {
             validate { it.demandValue("@event_name", "behov") }
             validate { it.demandAll("@behov", listOf(behov)) }
-            validate { it.requireKey("søknad_uuid", behov) }
+            validate { it.requireKey("søknad_uuid") }
             validate { it.forbid("@løsning") }
         }.register(this)
     }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadPersistence.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadPersistence.kt
@@ -14,5 +14,5 @@ interface SøknadPersistence {
     fun lagre(søknad: Søknad): Boolean
     fun opprettede(identer: Identer): Map<LocalDateTime, UUID>
     fun slett(uuid: UUID): Boolean
-    fun migrer(uuid: UUID): Prosessversjon
+    fun migrer(uuid: UUID, tilVersjon: Prosessversjon? = null): Prosessversjon
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadPersistence.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadPersistence.kt
@@ -14,4 +14,5 @@ interface SøknadPersistence {
     fun lagre(søknad: Søknad): Boolean
     fun opprettede(identer: Identer): Map<LocalDateTime, UUID>
     fun slett(uuid: UUID): Boolean
+    fun migrer(uuid: UUID): Prosessversjon
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecord.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecord.kt
@@ -129,9 +129,15 @@ class SøknadRecord : SøknadPersistence {
         val sisteVersjon = Versjon.siste(gjeldendeVersjon.prosessnavn)
 
         if (gjeldendeVersjon == sisteVersjon) return sisteVersjon
-        val gjeldendeFaktum = hentFaktum(gjeldendeVersjon)
-        val nyeFaktum = hentFaktum(sisteVersjon)
+        val gjeldendeFaktum = hentFaktum(gjeldendeVersjon).associateBy { it.id }
+        val nyeFaktum = hentFaktum(sisteVersjon).associateBy { it.id }
         val manglendeFaktum = nyeFaktum - gjeldendeFaktum
+
+        val nyeFaktumId = nyeFaktum.keys.toSet()
+        val gjeldendeFaktumId = nyeFaktum.keys.toSet()
+
+        val duplikater = gjeldendeFaktumId.intersect(nyeFaktumId)
+        val unike = nyeFaktumId.subtract(gjeldendeFaktumId)
 
         using(sessionOf(dataSource)) { session ->
             session.transaction { tx ->

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecord.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecord.kt
@@ -146,7 +146,7 @@ class SøknadRecord : SøknadPersistence {
         return nyVersjon
     }
 
-    private data class DbFaktum(val id: BigInteger, val rootId: Int) {
+    private data class FaktumMigrering(val id: BigInteger, val rootId: Int) {
         private fun opprettQuery(soknadId: BigInteger) = queryOf( //language=PostgreSQL
             "INSERT INTO faktum_verdi (soknad_id, indeks, faktum_id) VALUES (:soknadId, 0, :id)",
             mapOf("soknadId" to soknadId, "id" to id)
@@ -157,7 +157,7 @@ class SøknadRecord : SøknadPersistence {
             mapOf("nyId" to nyId, "gammelId" to gammelId)
         ).asUpdate
 
-        fun opprettEllerOppdater(forrigeFaktum: DbFaktum?, soknadId: BigInteger) = when (forrigeFaktum) {
+        fun opprettEllerOppdater(forrigeFaktum: FaktumMigrering?, soknadId: BigInteger) = when (forrigeFaktum) {
             null -> opprettQuery(soknadId)
             else -> oppdaterQuery(forrigeFaktum.id, id)
         }
@@ -188,7 +188,7 @@ class SøknadRecord : SøknadPersistence {
             sisteVersjon.prosessnavn.id,
             sisteVersjon.versjon
         ).map {
-            DbFaktum(
+            FaktumMigrering(
                 id = it.bigDecimal("id").toBigInteger(),
                 rootId = it.int("root_id")
             )

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/behovløsere/FornyVersjonServiceTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/behovløsere/FornyVersjonServiceTest.kt
@@ -1,0 +1,47 @@
+package no.nav.dagpenger.quiz.mediator.behovløsere
+
+import io.mockk.mockk
+import no.nav.dagpenger.quiz.mediator.db.SøknadPersistence
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+internal class FornyVersjonServiceTest {
+    val søknadPersistence = mockk<SøknadPersistence>(relaxed = true)
+
+    private val rapid = TestRapid().apply {
+        MigrerProsessService(this, søknadPersistence)
+    }
+
+    @Test
+    fun `besvarer dokumentkravSvar`() {
+        val søknadUUID = UUID.randomUUID()
+
+        //language=JSON
+        rapid.sendTestMessage(
+            """{
+          "@event_name": "behov",
+          "@behovId": "test123",      
+          "@behov": [
+            "FornyVersjon"
+          ],
+          "søknad_uuid": "$søknadUUID",
+          "ident": "12345678913",
+          "@id": "12345",
+          "@opprettet": "2022-09-26T09:47:15.296036"
+        }
+            """.trimIndent()
+        )
+
+        with(rapid.inspektør) {
+            Assertions.assertNotNull(field(0, "@løsning"))
+            Assertions.assertEquals(søknadUUID.toString(), field(0, "@løsning")["FornyVersjon"].asText())
+        }
+
+        /*verify(exactly = 1) {
+            søknadPersistence.hent(søknadUUID, any())
+            søknadPersistence.lagre(any())
+        }*/
+    }
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/behovløsere/MigrerProsessServiceTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/behovløsere/MigrerProsessServiceTest.kt
@@ -1,13 +1,14 @@
 package no.nav.dagpenger.quiz.mediator.behovløsere
 
 import io.mockk.mockk
+import io.mockk.verify
 import no.nav.dagpenger.quiz.mediator.db.SøknadPersistence
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
-internal class FornyVersjonServiceTest {
+internal class MigrerProsessServiceTest {
     val søknadPersistence = mockk<SøknadPersistence>(relaxed = true)
 
     private val rapid = TestRapid().apply {
@@ -15,7 +16,7 @@ internal class FornyVersjonServiceTest {
     }
 
     @Test
-    fun `besvarer dokumentkravSvar`() {
+    fun `besvarer migreringsbehov`() {
         val søknadUUID = UUID.randomUUID()
 
         //language=JSON
@@ -24,7 +25,7 @@ internal class FornyVersjonServiceTest {
           "@event_name": "behov",
           "@behovId": "test123",      
           "@behov": [
-            "FornyVersjon"
+            "MigrerProsess"
           ],
           "søknad_uuid": "$søknadUUID",
           "ident": "12345678913",
@@ -36,12 +37,11 @@ internal class FornyVersjonServiceTest {
 
         with(rapid.inspektør) {
             Assertions.assertNotNull(field(0, "@løsning"))
-            Assertions.assertEquals(søknadUUID.toString(), field(0, "@løsning")["FornyVersjon"].asText())
+            Assertions.assertEquals(søknadUUID.toString(), field(0, "@løsning")["MigrerProsess"].asText())
         }
 
-        /*verify(exactly = 1) {
-            søknadPersistence.hent(søknadUUID, any())
-            søknadPersistence.lagre(any())
-        }*/
+        verify(exactly = 1) {
+            søknadPersistence.migrer(søknadUUID)
+        }
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/behovløsere/MigrerProsessServiceTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/behovløsere/MigrerProsessServiceTest.kt
@@ -41,7 +41,7 @@ internal class MigrerProsessServiceTest {
         }
 
         verify(exactly = 1) {
-            søknadPersistence.migrer(søknadUUID)
+            søknadPersistence.migrer(søknadUUID, any())
         }
     }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
@@ -368,13 +368,17 @@ internal class SøknadRecordTest {
         Postgres.withMigratedDb {
             byggOriginalSøknadprosess()
             val soknadUUID = originalSøknadprosess.søknad.uuid
-            assertEquals(søknadRecord.migrer(soknadUUID), SøknadEksempel1.prosessVersjon, "Migrering til samme versjon")
+            assertEquals(
+                søknadRecord.migrer(soknadUUID, SøknadEksempel1.prosessVersjon),
+                SøknadEksempel1.prosessVersjon,
+                "Migrering til samme versjon"
+            )
 
             originalSøknadprosess.desimaltall("f26").besvar(9.9)
 
             SøknadEksempel1.v2
             FaktumTable(SøknadEksempel1.prototypeFakta2)
-            val nyProsessVersjon = søknadRecord.migrer(soknadUUID)
+            val nyProsessVersjon = søknadRecord.migrer(soknadUUID, SøknadEksempel1.prosessVersjon2)
 
             assertEquals(SøknadEksempel1.prosessVersjon2, nyProsessVersjon)
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
@@ -24,7 +24,6 @@ import no.nav.dagpenger.model.seksjon.Versjon
 import no.nav.dagpenger.model.seksjon.Versjon.UserInterfaceType.Web
 import no.nav.dagpenger.quiz.mediator.db.PostgresDataSourceBuilder.dataSource
 import no.nav.dagpenger.quiz.mediator.helpers.Postgres
-import no.nav.dagpenger.quiz.mediator.helpers.SøknadEksempel
 import no.nav.dagpenger.quiz.mediator.helpers.SøknadEksempel1
 import no.nav.dagpenger.quiz.mediator.helpers.Testprosess
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -121,7 +120,6 @@ internal class SøknadRecordTest {
     fun `Skal kun slette besvarer hvis den ikke refererer til andre søknader`() = Postgres.withMigratedDb {
         FaktumTable(SøknadEksempel1.prototypeFakta1)
         søknadRecord = SøknadRecord()
-
         val søknadProsess1 = søknadRecord.ny(UNG_PERSON_FNR_2018, Web, SøknadEksempel1.prosessVersjon)
         val søknadProsess2 = søknadRecord.ny(UNG_PERSON_FNR_2018, Web, SøknadEksempel1.prosessVersjon)
         val besvarer = "123"
@@ -135,7 +133,8 @@ internal class SøknadRecordTest {
         assertRecordCount(1, "besvarer")
     }
 
-    @Test fun `Lagring og henting av fakta med kotliquery spesial tegn`() {
+    @Test
+    fun `Lagring og henting av fakta med kotliquery spesial tegn`() {
         Postgres.withMigratedDb {
             byggOriginalSøknadprosess()
             originalSøknadprosess.tekst(23).besvar(Tekst("? tekst1 asdfas?"))
@@ -145,7 +144,8 @@ internal class SøknadRecordTest {
         }
     }
 
-    @Test fun `lagring og henting av fakta`() {
+    @Test
+    fun `lagring og henting av fakta`() {
         Postgres.withMigratedDb {
             byggOriginalSøknadprosess()
 
@@ -322,7 +322,6 @@ internal class SøknadRecordTest {
     fun `Skal kunne lagre pågående perioder, mao sette feltet fom til NULL`() {
         Postgres.withMigratedDb {
             byggOriginalSøknadprosess()
-
             val pågåendePeriode = Periode(17.mai())
             originalSøknadprosess.periode(24).besvar(pågåendePeriode)
 
@@ -351,8 +350,10 @@ internal class SøknadRecordTest {
             val søknadUUId = UUID.randomUUID()
             FaktumTable(SøknadEksempel1.prototypeFakta1)
             søknadRecord = SøknadRecord()
-            originalSøknadprosess = søknadRecord.ny(UNG_PERSON_FNR_2018, Web, SøknadEksempel1.prosessVersjon, søknadUUId)
-            originalSøknadprosess = søknadRecord.ny(UNG_PERSON_FNR_2018, Web, SøknadEksempel1.prosessVersjon, søknadUUId)
+            originalSøknadprosess =
+                søknadRecord.ny(UNG_PERSON_FNR_2018, Web, SøknadEksempel1.prosessVersjon, søknadUUId)
+            originalSøknadprosess =
+                søknadRecord.ny(UNG_PERSON_FNR_2018, Web, SøknadEksempel1.prosessVersjon, søknadUUId)
 
             originalSøknadprosess.dato(2).besvar(LocalDate.now())
 
@@ -363,15 +364,15 @@ internal class SøknadRecordTest {
     @Test
     fun `Kan migrere`() {
         Postgres.withMigratedDb {
-            val søknadUUId = UUID.randomUUID()
-            FaktumTable(SøknadEksempel.prototypeSøknad1)
-            søknadRecord = SøknadRecord()
-            originalSøknadprosess = søknadRecord.ny(UNG_PERSON_FNR_2018, Web, SøknadEksempel.prosessVersjon, søknadUUId)
+            byggOriginalSøknadprosess()
+            val soknadUUID = originalSøknadprosess.søknad.uuid
+            assertEquals(søknadRecord.migrer(soknadUUID), SøknadEksempel1.prosessVersjon, "Migrering til samme versjon")
 
-            FaktumTable(SøknadEksempel1.prototypeFakta1)
-            val nyProsessVersjon = søknadRecord.migrer(søknadUUId)
+            SøknadEksempel1.v2
+            FaktumTable(SøknadEksempel1.prototypeFakta2)
+            val nyProsessVersjon = søknadRecord.migrer(soknadUUID)
 
-            assertEquals(SøknadEksempel1.prosessVersjon, nyProsessVersjon)
+            assertEquals(SøknadEksempel1.prosessVersjon2, nyProsessVersjon)
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
@@ -27,7 +27,9 @@ import no.nav.dagpenger.quiz.mediator.helpers.Postgres
 import no.nav.dagpenger.quiz.mediator.helpers.SøknadEksempel1
 import no.nav.dagpenger.quiz.mediator.helpers.Testprosess
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
@@ -368,11 +370,28 @@ internal class SøknadRecordTest {
             val soknadUUID = originalSøknadprosess.søknad.uuid
             assertEquals(søknadRecord.migrer(soknadUUID), SøknadEksempel1.prosessVersjon, "Migrering til samme versjon")
 
+            originalSøknadprosess.desimaltall("f26").besvar(9.9)
+
             SøknadEksempel1.v2
             FaktumTable(SøknadEksempel1.prototypeFakta2)
             val nyProsessVersjon = søknadRecord.migrer(soknadUUID)
 
             assertEquals(SøknadEksempel1.prosessVersjon2, nyProsessVersjon)
+
+            with(søknadRecord.hent(soknadUUID)) {
+                assertFalse(heltall("f26").erBesvart())
+                assertFalse(desimaltall("f27").erBesvart())
+
+                heltall("f26").besvar(12)
+                desimaltall("f27").besvar(1.3)
+
+                assertTrue(desimaltall("f27").erBesvart())
+                søknadRecord.lagre(this.søknad)
+            }
+            with(søknadRecord.hent(soknadUUID)) {
+
+                assertTrue(desimaltall("f27").erBesvart())
+            }
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
@@ -25,6 +25,7 @@ import no.nav.dagpenger.model.seksjon.Versjon.UserInterfaceType.Web
 import no.nav.dagpenger.quiz.mediator.db.PostgresDataSourceBuilder.dataSource
 import no.nav.dagpenger.quiz.mediator.helpers.Postgres
 import no.nav.dagpenger.quiz.mediator.helpers.SøknadEksempel1
+import no.nav.dagpenger.quiz.mediator.helpers.SøknadEksempel2
 import no.nav.dagpenger.quiz.mediator.helpers.Testprosess
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -376,11 +377,11 @@ internal class SøknadRecordTest {
 
             originalSøknadprosess.desimaltall("f26").besvar(9.9)
 
-            SøknadEksempel1.v2
-            FaktumTable(SøknadEksempel1.prototypeFakta2)
-            val nyProsessVersjon = søknadRecord.migrer(soknadUUID, SøknadEksempel1.prosessVersjon2)
+            SøknadEksempel2.v2
+            FaktumTable(SøknadEksempel2.prototypeFakta)
+            val nyProsessVersjon = søknadRecord.migrer(soknadUUID, SøknadEksempel2.prosessVersjon)
 
-            assertEquals(SøknadEksempel1.prosessVersjon2, nyProsessVersjon)
+            assertEquals(SøknadEksempel2.prosessVersjon, nyProsessVersjon)
 
             with(søknadRecord.hent(soknadUUID)) {
                 assertFalse(heltall("f26").erBesvart())
@@ -388,6 +389,13 @@ internal class SøknadRecordTest {
 
                 heltall("f26").besvar(12)
                 desimaltall("f27").besvar(1.3)
+                envalg("f28").besvar(Envalg("f28.valg1"))
+                tekst("f20").besvar(Tekst("Foo"))
+
+                assertThrows<IllegalArgumentException> {
+                    // Slettet og finnes ikke lenger
+                    tekst("f23").besvar(Tekst("Foo"))
+                }
 
                 assertTrue(desimaltall("f27").erBesvart())
                 søknadRecord.lagre(this.søknad)

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
@@ -24,6 +24,7 @@ import no.nav.dagpenger.model.seksjon.Versjon
 import no.nav.dagpenger.model.seksjon.Versjon.UserInterfaceType.Web
 import no.nav.dagpenger.quiz.mediator.db.PostgresDataSourceBuilder.dataSource
 import no.nav.dagpenger.quiz.mediator.helpers.Postgres
+import no.nav.dagpenger.quiz.mediator.helpers.SøknadEksempel
 import no.nav.dagpenger.quiz.mediator.helpers.SøknadEksempel1
 import no.nav.dagpenger.quiz.mediator.helpers.Testprosess
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -356,6 +357,21 @@ internal class SøknadRecordTest {
             originalSøknadprosess.dato(2).besvar(LocalDate.now())
 
             lagreHentOgSammenlign()
+        }
+    }
+
+    @Test
+    fun `Kan migrere`() {
+        Postgres.withMigratedDb {
+            val søknadUUId = UUID.randomUUID()
+            FaktumTable(SøknadEksempel.prototypeSøknad1)
+            søknadRecord = SøknadRecord()
+            originalSøknadprosess = søknadRecord.ny(UNG_PERSON_FNR_2018, Web, SøknadEksempel.prosessVersjon, søknadUUId)
+
+            FaktumTable(SøknadEksempel1.prototypeFakta1)
+            val nyProsessVersjon = søknadRecord.migrer(søknadUUId)
+
+            assertEquals(SøknadEksempel1.prosessVersjon, nyProsessVersjon)
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/SøknadRecordTest.kt
@@ -388,8 +388,8 @@ internal class SøknadRecordTest {
                 assertTrue(desimaltall("f27").erBesvart())
                 søknadRecord.lagre(this.søknad)
             }
-            with(søknadRecord.hent(soknadUUID)) {
 
+            with(søknadRecord.hent(soknadUUID)) {
                 assertTrue(desimaltall("f27").erBesvart())
             }
         }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/helpers/SøknadEksempel1.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/helpers/SøknadEksempel1.kt
@@ -26,8 +26,8 @@ enum class Testprosess(override val id: String) : Prosessnavn {
 }
 
 internal object SøknadEksempel1 {
-
     val prosessVersjon = Prosessversjon(Testprosess.Test, 888)
+    val prosessVersjon2 = Prosessversjon(Testprosess.Test, 889)
     internal val prototypeFakta1 = Søknad(
         prosessVersjon,
         boolsk faktum "f1" id 1 avhengerAv 11,
@@ -58,9 +58,41 @@ internal object SøknadEksempel1 {
         periode faktum "f24" id 24,
         land faktum "f25" id 25,
         desimaltall faktum "f26" id 26
-
     )
-
+    internal val prototypeFakta2 by lazy {
+        Søknad(
+            prosessVersjon2,
+            boolsk faktum "f1" id 1 avhengerAv 11,
+            dato faktum "f2" id 2,
+            dato faktum "f3" id 3,
+            dato faktum "f4" id 4,
+            dato faktum "f5" id 5,
+            inntekt faktum "f6" id 6,
+            inntekt faktum "f7" id 7,
+            inntekt faktum "f8" id 8,
+            inntekt faktum "f9" id 9,
+            boolsk faktum "f10" id 10,
+            dokument faktum "f11" id 11,
+            boolsk faktum "f12" id 12 avhengerAv 11,
+            dato faktum "f13" id 13,
+            boolsk faktum "f14" id 14,
+            heltall faktum "f15" id 15 genererer 16 og 17 og 18 avhengerAv 14,
+            heltall faktum "f16" id 16,
+            boolsk faktum "f17" id 17,
+            boolsk faktum "f18" id 18,
+            boolsk faktum "f19" id 19 avhengerAv 2 og 13,
+            maks dato "345" av 3 og 4 og 5 id 345,
+            maks dato "345213" av 345 og 2 og 13 id 345213,
+            envalg faktum "f20" med "envalg1" med "envalg2" id 20,
+            flervalg faktum "f21" med "flervalg1" med "flervalg2" med "flervalg3" id 21,
+            heltall faktum "f22" id 22,
+            tekst faktum "f23" id 23,
+            periode faktum "f24" id 24,
+            land faktum "f25" id 25,
+            desimaltall faktum "f26" id 26,
+            desimaltall faktum "f27" id 27
+        )
+    }
     private val webPrototypeSøknad = Søknadprosess(
         Seksjon(
             "seksjon",
@@ -68,7 +100,6 @@ internal object SøknadEksempel1 {
             *(prototypeFakta1.map { it }.toTypedArray())
         )
     )
-
     private val mobilePrototypeSøknad = Søknadprosess(
         Seksjon(
             "seksjon",
@@ -82,7 +113,6 @@ internal object SøknadEksempel1 {
             prototypeFakta1.boolsk(17)
         )
     )
-
     val v = Versjon.Bygger(
         prototypeFakta1,
         prototypeFakta1 boolsk 1 er true,
@@ -91,4 +121,14 @@ internal object SøknadEksempel1 {
             Versjon.UserInterfaceType.Mobile to mobilePrototypeSøknad
         )
     ).registrer()
+    val v2 by lazy {
+        Versjon.Bygger(
+            prototypeFakta2,
+            prototypeFakta2 boolsk 1 er true,
+            mapOf(
+                Versjon.UserInterfaceType.Web to webPrototypeSøknad,
+                Versjon.UserInterfaceType.Mobile to mobilePrototypeSøknad
+            )
+        ).registrer()
+    }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/helpers/SøknadEksempel1.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/helpers/SøknadEksempel1.kt
@@ -27,7 +27,6 @@ enum class Testprosess(override val id: String) : Prosessnavn {
 
 internal object SøknadEksempel1 {
     val prosessVersjon = Prosessversjon(Testprosess.Test, 888)
-    val prosessVersjon2 = Prosessversjon(Testprosess.Test, 889)
     internal val prototypeFakta1 = Søknad(
         prosessVersjon,
         boolsk faktum "f1" id 1 avhengerAv 11,
@@ -59,40 +58,6 @@ internal object SøknadEksempel1 {
         land faktum "f25" id 25,
         desimaltall faktum "f26" id 26
     )
-    internal val prototypeFakta2 by lazy {
-        Søknad(
-            prosessVersjon2,
-            boolsk faktum "f1" id 1 avhengerAv 11,
-            dato faktum "f2" id 2,
-            dato faktum "f3" id 3,
-            dato faktum "f4" id 4,
-            dato faktum "f5" id 5,
-            inntekt faktum "f6" id 6,
-            inntekt faktum "f7" id 7,
-            inntekt faktum "f8" id 8,
-            inntekt faktum "f9" id 9,
-            boolsk faktum "f10" id 10,
-            dokument faktum "f11" id 11,
-            boolsk faktum "f12" id 12 avhengerAv 11,
-            dato faktum "f13" id 13,
-            boolsk faktum "f14" id 14,
-            heltall faktum "f15" id 15 genererer 16 og 17 og 18 avhengerAv 14,
-            heltall faktum "f16" id 16,
-            boolsk faktum "f17" id 17,
-            boolsk faktum "f18" id 18,
-            boolsk faktum "f19" id 19 avhengerAv 2 og 13,
-            maks dato "345" av 3 og 4 og 5 id 345,
-            maks dato "345213" av 345 og 2 og 13 id 345213,
-            envalg faktum "f20" med "envalg1" med "envalg2" id 20,
-            flervalg faktum "f21" med "flervalg1" med "flervalg2" med "flervalg3" id 21,
-            heltall faktum "f22" id 22,
-            tekst faktum "f23" id 23,
-            periode faktum "f24" id 24,
-            land faktum "f25" id 25,
-            heltall faktum "f26" id 26,
-            desimaltall faktum "f27" id 27
-        )
-    }
     private val webPrototypeSøknad = Søknadprosess(
         Seksjon(
             "seksjon",
@@ -121,14 +86,4 @@ internal object SøknadEksempel1 {
             Versjon.UserInterfaceType.Mobile to mobilePrototypeSøknad
         )
     ).registrer()
-    val v2 by lazy {
-        Versjon.Bygger(
-            prototypeFakta2,
-            prototypeFakta2 boolsk 1 er true,
-            mapOf(
-                Versjon.UserInterfaceType.Web to webPrototypeSøknad,
-                Versjon.UserInterfaceType.Mobile to mobilePrototypeSøknad
-            )
-        ).registrer()
-    }
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/helpers/SøknadEksempel1.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/helpers/SøknadEksempel1.kt
@@ -22,7 +22,7 @@ import no.nav.dagpenger.model.seksjon.Søknadprosess
 import no.nav.dagpenger.model.seksjon.Versjon
 
 enum class Testprosess(override val id: String) : Prosessnavn {
-    Test("test")
+    Test("test-r")
 }
 
 internal object SøknadEksempel1 {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/helpers/SøknadEksempel1.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/helpers/SøknadEksempel1.kt
@@ -89,7 +89,7 @@ internal object SøknadEksempel1 {
             tekst faktum "f23" id 23,
             periode faktum "f24" id 24,
             land faktum "f25" id 25,
-            desimaltall faktum "f26" id 26,
+            heltall faktum "f26" id 26,
             desimaltall faktum "f27" id 27
         )
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/helpers/SøknadEksempel2.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/helpers/SøknadEksempel2.kt
@@ -1,0 +1,89 @@
+package no.nav.dagpenger.quiz.mediator.helpers
+
+import no.nav.dagpenger.model.factory.BaseFaktumFactory.Companion.boolsk
+import no.nav.dagpenger.model.factory.BaseFaktumFactory.Companion.dato
+import no.nav.dagpenger.model.factory.BaseFaktumFactory.Companion.desimaltall
+import no.nav.dagpenger.model.factory.BaseFaktumFactory.Companion.dokument
+import no.nav.dagpenger.model.factory.BaseFaktumFactory.Companion.envalg
+import no.nav.dagpenger.model.factory.BaseFaktumFactory.Companion.flervalg
+import no.nav.dagpenger.model.factory.BaseFaktumFactory.Companion.heltall
+import no.nav.dagpenger.model.factory.BaseFaktumFactory.Companion.inntekt
+import no.nav.dagpenger.model.factory.BaseFaktumFactory.Companion.land
+import no.nav.dagpenger.model.factory.BaseFaktumFactory.Companion.periode
+import no.nav.dagpenger.model.factory.BaseFaktumFactory.Companion.tekst
+import no.nav.dagpenger.model.factory.UtledetFaktumFactory.Companion.maks
+import no.nav.dagpenger.model.faktum.Prosessversjon
+import no.nav.dagpenger.model.faktum.Rolle
+import no.nav.dagpenger.model.faktum.Søknad
+import no.nav.dagpenger.model.regel.er
+import no.nav.dagpenger.model.seksjon.Seksjon
+import no.nav.dagpenger.model.seksjon.Søknadprosess
+import no.nav.dagpenger.model.seksjon.Versjon
+
+internal object SøknadEksempel2 {
+    val prosessVersjon = Prosessversjon(Testprosess.Test, 889)
+    internal val prototypeFakta by lazy {
+        Søknad(
+            prosessVersjon,
+            boolsk faktum "f1" id 1 avhengerAv 11,
+            dato faktum "f2" id 2,
+            dato faktum "f3" id 3,
+            dato faktum "f4" id 4,
+            dato faktum "f5" id 5,
+            inntekt faktum "f6" id 6,
+            inntekt faktum "f7" id 7,
+            inntekt faktum "f8" id 8,
+            inntekt faktum "f9" id 9,
+            boolsk faktum "f10" id 10,
+            dokument faktum "f11" id 11,
+            boolsk faktum "f12" id 12 avhengerAv 11,
+            dato faktum "f13" id 13,
+            boolsk faktum "f14" id 14,
+            heltall faktum "f15" id 15 genererer 16 og 17 og 18 avhengerAv 14,
+            heltall faktum "f16" id 16,
+            boolsk faktum "f17" id 17,
+            boolsk faktum "f18" id 18,
+            boolsk faktum "f19" id 19 avhengerAv 2 og 13,
+            maks dato "345" av 3 og 4 og 5 id 345,
+            maks dato "345213" av 345 og 2 og 13 id 345213,
+            tekst faktum "f20" med "envalg1" med "envalg2" id 20,
+            flervalg faktum "f21" med "flervalg1" med "flervalg2" med "flervalg3" id 21,
+            heltall faktum "f22" id 22,
+            periode faktum "f24" id 24,
+            land faktum "f25" id 25,
+            heltall faktum "f26" id 26,
+            desimaltall faktum "f27" id 27,
+            envalg faktum "f28" med "valg1" med "valg2" id 28
+        )
+    }
+    private val webPrototypeSøknad = Søknadprosess(
+        Seksjon(
+            "seksjon",
+            Rolle.søker,
+            *(prototypeFakta.map { it }.toTypedArray())
+        )
+    )
+    private val mobilePrototypeSøknad = Søknadprosess(
+        Seksjon(
+            "seksjon",
+            Rolle.søker,
+            *(prototypeFakta.map { it }.toTypedArray())
+        ),
+        Seksjon(
+            "template seksjon",
+            Rolle.søker,
+            prototypeFakta.heltall(16),
+            prototypeFakta.boolsk(17)
+        )
+    )
+    val v2 by lazy {
+        Versjon.Bygger(
+            prototypeFakta,
+            prototypeFakta boolsk 1 er true,
+            mapOf(
+                Versjon.UserInterfaceType.Web to webPrototypeSøknad,
+                Versjon.UserInterfaceType.Mobile to mobilePrototypeSøknad
+            )
+        ).registrer()
+    }
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/SøknadPersistenceFake.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/SøknadPersistenceFake.kt
@@ -39,7 +39,7 @@ internal class SøknadPersistenceFake : SøknadPersistence {
         TODO("Not yet implemented")
     }
 
-    override fun migrer(uuid: UUID): Prosessversjon {
+    override fun migrer(uuid: UUID, tilVersjon: Prosessversjon?): Prosessversjon {
         TODO("Not yet implemented")
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/SøknadPersistenceFake.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/SøknadPersistenceFake.kt
@@ -39,6 +39,10 @@ internal class SøknadPersistenceFake : SøknadPersistence {
         TODO("Not yet implemented")
     }
 
+    override fun migrer(uuid: UUID): Prosessversjon {
+        TODO("Not yet implemented")
+    }
+
     fun reset() {
         søknadprosess = null
         hentet = 0

--- a/model/src/main/kotlin/no/nav/dagpenger/model/faktum/Prosessversjon.kt
+++ b/model/src/main/kotlin/no/nav/dagpenger/model/faktum/Prosessversjon.kt
@@ -1,11 +1,12 @@
 package no.nav.dagpenger.model.faktum
 
+import no.nav.dagpenger.model.seksjon.Versjon
+
 interface Prosessnavn {
     val id: String
 }
 
 class Prosessversjon(val prosessnavn: Prosessnavn, val versjon: Int) {
-
     internal companion object {
         val prototypeversjon = Prosessversjon(
             object : Prosessnavn {
@@ -15,11 +16,14 @@ class Prosessversjon(val prosessnavn: Prosessnavn, val versjon: Int) {
         )
     }
 
+    fun siste() = Versjon.siste(prosessnavn)
+
     init {
         require(prosessnavn.id.isNotBlank()) { "Prosessnavn kan ikke være blank" }
     }
 
-    override fun equals(other: Any?): Boolean = other is Prosessversjon && other.prosessnavn.id == this.prosessnavn.id && other.versjon == this.versjon
+    override fun equals(other: Any?): Boolean =
+        other is Prosessversjon && other.prosessnavn.id == this.prosessnavn.id && other.versjon == this.versjon
 
     override fun hashCode(): Int = prosessnavn.id.hashCode() * 37 + versjon.hashCode()
 

--- a/model/src/main/kotlin/no/nav/dagpenger/model/faktum/Prosessversjon.kt
+++ b/model/src/main/kotlin/no/nav/dagpenger/model/faktum/Prosessversjon.kt
@@ -19,10 +19,10 @@ class Prosessversjon(val prosessnavn: Prosessnavn, val versjon: Int) {
     fun siste() = Versjon.siste(prosessnavn)
 
     fun kanMigrereTil(tilVersjon: Prosessversjon): Boolean {
-        require(tilVersjon?.prosessnavn == prosessnavn) { "Kan ikke migrere til en annen prosesstype." }
-        require(versjon > tilVersjon.versjon) { "Kan ikke migrere bakover. Gjeldende versjon er $versjon, forsøkte å migrere til ${tilVersjon.versjon}" }
+        require(tilVersjon.prosessnavn.id == prosessnavn.id) { "Kan ikke migrere til en annen prosesstype." }
+        require(tilVersjon.versjon >= versjon) { "Kan ikke migrere bakover. Gjeldende versjon er $versjon, forsøkte å migrere til ${tilVersjon.versjon}" }
 
-        return this == tilVersjon
+        return this != tilVersjon
     }
 
     init {

--- a/model/src/main/kotlin/no/nav/dagpenger/model/faktum/Prosessversjon.kt
+++ b/model/src/main/kotlin/no/nav/dagpenger/model/faktum/Prosessversjon.kt
@@ -18,6 +18,13 @@ class Prosessversjon(val prosessnavn: Prosessnavn, val versjon: Int) {
 
     fun siste() = Versjon.siste(prosessnavn)
 
+    fun kanMigrereTil(tilVersjon: Prosessversjon): Boolean {
+        require(tilVersjon?.prosessnavn == prosessnavn) { "Kan ikke migrere til en annen prosesstype." }
+        require(versjon > tilVersjon.versjon) { "Kan ikke migrere bakover. Gjeldende versjon er $versjon, forsøkte å migrere til ${tilVersjon.versjon}" }
+
+        return this == tilVersjon
+    }
+
     init {
         require(prosessnavn.id.isNotBlank()) { "Prosessnavn kan ikke være blank" }
     }


### PR DESCRIPTION
Lager støtte for migrering av søknadsprosesser når vi endrer versjonsnummer.

Å migrere er en opt-in ting som må gjøres fra utsiden, Quiz legger ingen føringer på hvilke prosesser som kan migreres.

Migrering innebærer:
- Alle faktum for en søknad med samme rootId som før blir "flyttet fram" til nytt faktum. 
- Alle faktum for en søknad med samme rootId, men ny type vil bli ubesvart (men det gamle svaret ligger i databasen)
- Alle faktum som legges til vil bli lagt til som ubesvart.