### PR TITLE
PDL sender landkoden XXX i tilfeller hvor landet er ukjent

### DIFF
--- a/model/src/main/kotlin/no/nav/dagpenger/model/faktum/Land.kt
+++ b/model/src/main/kotlin/no/nav/dagpenger/model/faktum/Land.kt
@@ -3,6 +3,7 @@ package no.nav.dagpenger.model.faktum
 class Land(alpha3Code: String) : Comparable<Land> {
     companion object {
         internal val gyldigeLand = LandOppslag.land()
+        internal val pdlKodeForUkjentLand = "XXX"
     }
 
     val alpha3Code: String
@@ -11,12 +12,17 @@ class Land(alpha3Code: String) : Comparable<Land> {
         require(alpha3Code.length == 3) {
             "ISO 3166-1-alpha3 må være 3 bokstaver lang. Fikk: $alpha3Code"
         }
-        require(LandOppslag.fraAlpha3Code(alpha3Code) != null) {
-            "Ugyldig land kode: $alpha3Code"
+
+        if (alpha3Code.erAntattKjentLand()) {
+            require(LandOppslag.fraAlpha3Code(alpha3Code) != null) {
+                "Ugyldig land kode: $alpha3Code"
+            }
         }
 
         this.alpha3Code = alpha3Code.uppercase()
     }
+
+    private fun String.erAntattKjentLand() = !pdlKodeForUkjentLand.equals(this, ignoreCase = true)
 
     override fun compareTo(other: Land): Int {
         return this.alpha3Code.compareTo(other.alpha3Code)

--- a/model/src/test/kotlin/no/nav/dagpenger/model/unit/faktum/LandTest.kt
+++ b/model/src/test/kotlin/no/nav/dagpenger/model/unit/faktum/LandTest.kt
@@ -1,9 +1,9 @@
 package no.nav.dagpenger.model.unit.faktum
 
-import no.nav.dagpenger.model.factory.BaseFaktumFactory.Companion.land
 import no.nav.dagpenger.model.faktum.Land
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -34,5 +34,11 @@ internal class LandTest {
     fun `case insentivity`() {
         assertEquals(Land("NOR"), Land("nor"))
         assertEquals(Land("nOR"), Land("Nor"))
+    }
+
+    @Test
+    fun `Må tillate PDL sin kode for ukjent land`() {
+        assertDoesNotThrow { Land(Land.pdlKodeForUkjentLand) }
+        assertDoesNotThrow { Land(Land.pdlKodeForUkjentLand.lowercase()) }
     }
 }


### PR DESCRIPTION
Dermed må dette også tillates i Quiz som et gyldig landvalg.