### PR TITLE
PDL kan returnere både statsløs og ukjent som statsborgerskap

### DIFF
--- a/model/src/main/kotlin/no/nav/dagpenger/model/faktum/Land.kt
+++ b/model/src/main/kotlin/no/nav/dagpenger/model/faktum/Land.kt
@@ -3,7 +3,8 @@ package no.nav.dagpenger.model.faktum
 class Land(alpha3Code: String) : Comparable<Land> {
     companion object {
         internal val gyldigeLand = LandOppslag.land()
-        internal val pdlKodeForUkjentLand = "XXX"
+        internal val pdlKodeForUkjentLand = "XUK"
+        internal val pdlKodeForStatsløs = "XXX"
     }
 
     val alpha3Code: String
@@ -22,7 +23,9 @@ class Land(alpha3Code: String) : Comparable<Land> {
         this.alpha3Code = alpha3Code.uppercase()
     }
 
-    private fun String.erAntattKjentLand() = !pdlKodeForUkjentLand.equals(this, ignoreCase = true)
+    private fun String.erAntattKjentLand() =
+        !pdlKodeForUkjentLand.equals(this, ignoreCase = true) &&
+            !pdlKodeForStatsløs.equals(this, ignoreCase = true)
 
     override fun compareTo(other: Land): Int {
         return this.alpha3Code.compareTo(other.alpha3Code)

--- a/model/src/test/kotlin/no/nav/dagpenger/model/unit/faktum/LandTest.kt
+++ b/model/src/test/kotlin/no/nav/dagpenger/model/unit/faktum/LandTest.kt
@@ -40,5 +40,13 @@ internal class LandTest {
     fun `Må tillate PDL sin kode for ukjent land`() {
         assertDoesNotThrow { Land(Land.pdlKodeForUkjentLand) }
         assertDoesNotThrow { Land(Land.pdlKodeForUkjentLand.lowercase()) }
+        assertDoesNotThrow { Land("xUk") }
+    }
+
+    @Test
+    fun `Må tillate PDL sin kode for statsløs`() {
+        assertDoesNotThrow { Land(Land.pdlKodeForStatsløs) }
+        assertDoesNotThrow { Land(Land.pdlKodeForStatsløs.lowercase()) }
+        assertDoesNotThrow { Land("xXx") }
     }
 }


### PR DESCRIPTION
"I statsborgerskap kan personer kan ha kode for ukjent (XUK) eller statsløs (XXX)."

Drøyer med å prodsette denne for å slippe mer rebalansering nå.