### PR TITLE
La til støtte for å ta i mot pdl sin kode for Kosovo

### DIFF
--- a/model/src/main/kotlin/no/nav/dagpenger/model/faktum/Land.kt
+++ b/model/src/main/kotlin/no/nav/dagpenger/model/faktum/Land.kt
@@ -3,8 +3,11 @@ package no.nav.dagpenger.model.faktum
 class Land(alpha3Code: String) : Comparable<Land> {
     companion object {
         internal val gyldigeLand = LandOppslag.land()
-        internal val pdlKodeForUkjentLand = "XUK"
+
+        internal val landkodeForKosovo = "XXK"
         internal val pdlKodeForStatsløs = "XXX"
+        internal val pdlKodeForUkjentLand = "XUK"
+        internal val pdlSpesialkoder = setOf(landkodeForKosovo, pdlKodeForStatsløs, pdlKodeForUkjentLand)
     }
 
     val alpha3Code: String
@@ -14,7 +17,7 @@ class Land(alpha3Code: String) : Comparable<Land> {
             "ISO 3166-1-alpha3 må være 3 bokstaver lang. Fikk: $alpha3Code"
         }
 
-        if (alpha3Code.erAntattKjentLand()) {
+        if (alpha3Code.erAntattAnerkjentLand()) {
             require(LandOppslag.fraAlpha3Code(alpha3Code) != null) {
                 "Ugyldig land kode: $alpha3Code"
             }
@@ -23,9 +26,8 @@ class Land(alpha3Code: String) : Comparable<Land> {
         this.alpha3Code = alpha3Code.uppercase()
     }
 
-    private fun String.erAntattKjentLand() =
-        !pdlKodeForUkjentLand.equals(this, ignoreCase = true) &&
-            !pdlKodeForStatsløs.equals(this, ignoreCase = true)
+    private fun String.erAntattAnerkjentLand() =
+        pdlSpesialkoder.find { spesialkode -> spesialkode.equals(this, ignoreCase = true) } == null
 
     override fun compareTo(other: Land): Int {
         return this.alpha3Code.compareTo(other.alpha3Code)

--- a/model/src/test/kotlin/no/nav/dagpenger/model/unit/faktum/LandTest.kt
+++ b/model/src/test/kotlin/no/nav/dagpenger/model/unit/faktum/LandTest.kt
@@ -49,4 +49,11 @@ internal class LandTest {
         assertDoesNotThrow { Land(Land.pdlKodeForStatsløs.lowercase()) }
         assertDoesNotThrow { Land("xXx") }
     }
+
+    @Test
+    fun `Må tillate den uoffisielle koden for Kosovo, siden PDL kan returnere den`() {
+        assertDoesNotThrow { Land(Land.landkodeForKosovo) }
+        assertDoesNotThrow { Land(Land.landkodeForKosovo.lowercase()) }
+        assertDoesNotThrow { Land("XXK") }
+    }
 }


### PR DESCRIPTION
Kosovo er ikke en stat som alle land anerkjenner, og har dermed ikke en offisiell kode. Men PDL har en egen kode for Kosovo, og dermed må vi støtte denne.

Vi får kanskje vurdere å lage en jiraoppgave på å gå skikkelige igjennom landlista vi leser inn fra fil, slik at vi er sikre på at vi kan ta imot alle koder som PDL kan svare med. Foreløpig har jeg kun lagt til støtte for de kodene som har dukket opp i loggene pga at vi har avvist de.