### PR TITLE
Fakta kan ikke slettes uten at den tilhørende prosessen slettes først

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/ApplicationBuilder.kt
@@ -52,10 +52,10 @@ internal class ApplicationBuilder : RapidsConnection.StatusListener {
         runMigration()
             .also {
                 val faktaRecord = FaktaRecord()
-                val utredningsprosessRepository = ProsessRepositoryPostgres()
+                val prosessRepository = ProsessRepositoryPostgres()
                 val resultatRecord = ResultatRecord()
                 AvslagPåMinsteinntektOppsett.registrer { prototypeSøknad -> FaktumTable(prototypeSøknad) }
-                AvslagPåMinsteinntektService(utredningsprosessRepository, rapidsConnection)
+                AvslagPåMinsteinntektService(prosessRepository, rapidsConnection)
 
                 Dagpenger248.registrer {
                     logger.info("Sørger for å støtte gamle versjoner, registrerer dagpenger versjon 248")
@@ -77,23 +77,23 @@ internal class ApplicationBuilder : RapidsConnection.StatusListener {
                     Paragraf_4_23_alder_oppsett.registrer { prototype ->
                         FaktumTable(prototype)
                     }
-                    VilkårsvurderingLøser(rapidsConnection, utredningsprosessRepository)
+                    VilkårsvurderingLøser(rapidsConnection, prosessRepository)
                 }
 
-                NyProsessBehovLøser(utredningsprosessRepository, rapidsConnection)
-                FaktumSvarService(utredningsprosessRepository, resultatRecord, rapidsConnection)
+                NyProsessBehovLøser(prosessRepository, rapidsConnection)
+                FaktumSvarService(prosessRepository, resultatRecord, rapidsConnection)
                 BehandlingsdatoService(rapidsConnection)
                 SenesteMuligeVirkningsdatoService(rapidsConnection)
                 TerskelFaktorService(rapidsConnection)
                 ManuellBehandlingSink(rapidsConnection, resultatRecord)
-                SøknadSlettetService(rapidsConnection, faktaRecord)
+                SøknadSlettetService(rapidsConnection, prosessRepository)
                 MetadataService(
                     rapidsConnection,
-                    utredningsprosessRepository,
+                    prosessRepository,
                     ProsessMetadataStrategi(),
                 )
-                DokumentkravSvarService(rapidsConnection, utredningsprosessRepository)
-                MigrerProsessService(rapidsConnection, faktaRecord, utredningsprosessRepository)
+                DokumentkravSvarService(rapidsConnection, prosessRepository)
+                MigrerProsessService(rapidsConnection, faktaRecord, prosessRepository)
             }
     }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/db/ProsessRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/db/ProsessRepository.kt
@@ -15,4 +15,5 @@ interface ProsessRepository {
 
     fun hent(uuid: UUID): Prosess
     fun lagre(prosess: Prosess): Boolean
+    fun slett(uuid: UUID)
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/SøknadSlettetService.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/SøknadSlettetService.kt
@@ -1,7 +1,7 @@
 package no.nav.dagpenger.quiz.mediator.meldinger
 
 import mu.KotlinLogging
-import no.nav.dagpenger.quiz.mediator.db.FaktaRepository
+import no.nav.dagpenger.quiz.mediator.db.ProsessRepository
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
@@ -11,11 +11,12 @@ import java.util.UUID
 
 internal class SøknadSlettetService(
     rapidsConnection: RapidsConnection,
-    private val faktaRepository: FaktaRepository,
+    private val prosessRepository: ProsessRepository,
 ) : River.PacketListener {
 
     companion object {
         private val logger = KotlinLogging.logger {}
+        private val sikkerlogg = KotlinLogging.logger("tjenestekall")
     }
 
     init {
@@ -30,9 +31,9 @@ internal class SøknadSlettetService(
         withMDC("søknad_uuid" to uuid.toString()) {
             try {
                 logger.info { "Forsøker å slette søknad: $uuid" }
-                faktaRepository.slett(uuid)
+                prosessRepository.slett(uuid)
             } catch (e: Exception) {
-                logger.error { "Sletting av søknad med uuid: $uuid feilet" }
+                sikkerlogg.error(e) { "Sletting av søknad med uuid: $uuid feilet" }
             }
         }
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/AvhengigeFaktaTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/db/AvhengigeFaktaTest.kt
@@ -77,7 +77,7 @@ internal class AvhengigeFaktaTest {
                 )
             }
             FaktumTable(prototypeFakta)
-            originalProsess = utredningsprosess(prosesstype)
+            originalProsess = prosess(prosesstype)
 
             originalProsess.dato(2).besvar(2.januar)
             originalProsess.dato(13).besvar(13.januar)
@@ -121,7 +121,7 @@ internal class AvhengigeFaktaTest {
             }
 
             FaktumTable(prototypeFakta)
-            originalProsess = utredningsprosess(prosesstype)
+            originalProsess = prosess(prosesstype)
 
             originalProsess.boolsk(2).besvar(true)
             originalProsess.boolsk(5).besvar(true)
@@ -166,7 +166,7 @@ internal class AvhengigeFaktaTest {
             }
 
             FaktumTable(prototypeFakta)
-            originalProsess = utredningsprosess(prosesstype)
+            originalProsess = prosess(prosesstype)
 
             originalProsess.dato(2).besvar(1.januar)
             originalProsess.dato(3).besvar(10.januar)
@@ -220,7 +220,7 @@ internal class AvhengigeFaktaTest {
             }
 
             FaktumTable(prototypeFakta)
-            originalProsess = utredningsprosess(prosesstype)
+            originalProsess = prosess(prosesstype)
 
             originalProsess.boolsk(1).besvar(true)
             originalProsess.dato(2).besvar(10.januar)
@@ -263,7 +263,7 @@ internal class AvhengigeFaktaTest {
         override val faktatype: Faktatype = faktatype
     }
 
-    private fun utredningsprosess(prosesstype: Prosesstype): Prosess {
+    private fun prosess(prosesstype: Prosesstype): Prosess {
         return prosessRepository.ny(UNG_PERSON_FNR_2018, prosesstype)
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/FaktaSlettetServiceTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/FaktaSlettetServiceTest.kt
@@ -3,25 +3,24 @@ package no.nav.dagpenger.quiz.mediator.meldinger
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.dagpenger.quiz.mediator.db.FaktaRepository
+import no.nav.dagpenger.quiz.mediator.db.ProsessRepository
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import java.lang.Exception
 import java.util.UUID
 
 internal class FaktaSlettetServiceTest {
 
     val søknadUUIDfeilerIkke = UUID.randomUUID()
     val søknadUUIDfeiler = UUID.randomUUID()
-    val faktaRepository = mockk<FaktaRepository>(relaxed = true).also {
+    val prosessRepository = mockk<ProsessRepository>(relaxed = true).also {
         every { it.slett(søknadUUIDfeiler) } throws Exception("Noe gikk galt under sletting")
-        every { it.slett(søknadUUIDfeilerIkke) } returns true
+        every { it.slett(søknadUUIDfeilerIkke) } returns Unit
     }
     val testRapid = TestRapid().also {
         SøknadSlettetService(
             rapidsConnection = it,
-            faktaRepository = faktaRepository,
+            prosessRepository = prosessRepository,
         )
     }
 
@@ -29,7 +28,7 @@ internal class FaktaSlettetServiceTest {
     fun `tar i mot søknadSlettetEvent`() {
         testRapid.sendTestMessage(søknadSlettetEvent(søknadUUIDfeilerIkke))
         verify {
-            faktaRepository.slett(søknadUUIDfeilerIkke)
+            prosessRepository.slett(søknadUUIDfeilerIkke)
         }
     }
 
@@ -38,7 +37,7 @@ internal class FaktaSlettetServiceTest {
         assertDoesNotThrow {
             testRapid.sendTestMessage(søknadSlettetEvent(søknadUUIDfeiler))
             verify {
-                faktaRepository.slett(søknadUUIDfeiler)
+                prosessRepository.slett(søknadUUIDfeiler)
             }
         }
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/ProsessRepositoryFake.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/meldinger/ProsessRepositoryFake.kt
@@ -25,6 +25,10 @@ internal class ProsessRepositoryFake(private val prosesstype: Prosesstype, priva
         return true
     }
 
+    override fun slett(uuid: UUID) {
+        prosess = null
+    }
+
     fun reset() {
         prosess = null
         hentet = 0


### PR DESCRIPTION
Dette skal løse problemet vi ser i loggene med innslag av typen `Sletting av søknad med uuid: <UUID> feilet`.