### PR TITLE
Task/endre mulig gjenopptak sjekk

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
 
   deploy-dev:
     needs: [ build ]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/task/endre-mulig-gjenopptak-sjekk'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminsteinntekt/AvslagPåMinsteinntektOppsett.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminsteinntekt/AvslagPåMinsteinntektOppsett.kt
@@ -49,7 +49,7 @@ internal object AvslagPåMinsteinntektOppsett {
     const val permittert = 28
     const val lønnsgaranti = 29
     const val permittertFiskeforedling = 30
-    const val harHattDagpengerSiste36mnd = 32
+    const val harHattDagpengerSiste13mnd = 32
     const val periodeOppbruktManuell = 33
     const val sykepengerSiste36mnd = 34
     const val svangerskapsrelaterteSykepengerManuell = 35
@@ -100,8 +100,8 @@ internal object AvslagPåMinsteinntektOppsett {
             boolsk faktum "Ordinær" id ordinær,
             boolsk faktum "Lønnsgaranti" id lønnsgaranti,
             boolsk faktum "PermittertFiskeforedling" id permittertFiskeforedling,
-            boolsk faktum "Har hatt dagpenger siste 36mnd" id harHattDagpengerSiste36mnd avhengerAv virkningsdato,
-            boolsk faktum "Har brukt opp forrige dagpengeperiode" id periodeOppbruktManuell avhengerAv harHattDagpengerSiste36mnd,
+            boolsk faktum "Har hatt dagpenger siste 13mnd" id harHattDagpengerSiste13mnd avhengerAv virkningsdato,
+            boolsk faktum "Har brukt opp forrige dagpengeperiode" id periodeOppbruktManuell avhengerAv harHattDagpengerSiste13mnd,
             boolsk faktum "Sykepenger siste 36 mnd" id sykepengerSiste36mnd avhengerAv virkningsdato,
             boolsk faktum "Svangerskapsrelaterte sykepenger" id svangerskapsrelaterteSykepengerManuell avhengerAv sykepengerSiste36mnd,
             boolsk faktum "Fangst og fisk manuell" id fangstOgFiskManuell avhengerAv fangstOgFiskInntektSiste36mnd,
@@ -150,7 +150,7 @@ internal object AvslagPåMinsteinntektOppsett {
                 permittert to "Permittert",
                 lønnsgaranti to "Lønnsgaranti",
                 permittertFiskeforedling to "PermittertFiskeforedling",
-                harHattDagpengerSiste36mnd to "HarHattDagpengerSiste36Mnd",
+                harHattDagpengerSiste13mnd to "HarHattDagpengerSiste13Mnd",
                 sykepengerSiste36mnd to "SykepengerSiste36Måneder",
                 eøsArbeid to "EØSArbeid",
                 harInntektNesteKalendermåned to "HarRapportertInntektNesteMåned",

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminsteinntekt/AvslagPåMinsteinntektOppsett.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminsteinntekt/AvslagPåMinsteinntektOppsett.kt
@@ -28,7 +28,6 @@ internal object AvslagPåMinsteinntektOppsett {
 
     const val ønsketDato = 1
     const val virkningsdato = 4
-    const val fangstOgFiskInntektSiste36mnd = 5
     const val inntektSiste36mnd = 6
     const val inntektSiste12mnd = 7
     const val minsteinntektfaktor36mnd = 8
@@ -53,7 +52,6 @@ internal object AvslagPåMinsteinntektOppsett {
     const val periodeOppbruktManuell = 33
     const val sykepengerSiste36mnd = 34
     const val svangerskapsrelaterteSykepengerManuell = 35
-    const val fangstOgFiskManuell = 36
     const val eøsArbeid = 37
     const val eøsArbeidManuell = 38
     const val uhåndterbartVirkningsdatoManuell = 39
@@ -80,9 +78,8 @@ internal object AvslagPåMinsteinntektOppsett {
             VERSJON_ID,
             dato faktum "Ønsker dagpenger fra dato" id ønsketDato avhengerAv innsendtSøknadsId,
             maks dato "Virkningsdato" av ønsketDato og søknadstidspunkt id virkningsdato,
-            boolsk faktum "Har hatt inntekt fra fangst og fisk siste 36 mnd" id fangstOgFiskInntektSiste36mnd avhengerAv virkningsdato,
-            inntekt faktum "Inntekt siste 36 mnd" id inntektSiste36mnd avhengerAv virkningsdato og fangstOgFiskInntektSiste36mnd,
-            inntekt faktum "Inntekt siste 12 mnd" id inntektSiste12mnd avhengerAv virkningsdato og fangstOgFiskInntektSiste36mnd,
+            inntekt faktum "Inntekt siste 36 mnd" id inntektSiste36mnd avhengerAv virkningsdato,
+            inntekt faktum "Inntekt siste 12 mnd" id inntektSiste12mnd avhengerAv virkningsdato,
             inntekt faktum "Grunnbeløp" id grunnbeløp avhengerAv virkningsdato,
             desimaltall faktum "Øvre faktor" id minsteinntektfaktor36mnd avhengerAv virkningsdato,
             desimaltall faktum "Nedre faktor" id minsteinntektfaktor12mnd avhengerAv virkningsdato,
@@ -104,7 +101,6 @@ internal object AvslagPåMinsteinntektOppsett {
             boolsk faktum "Har brukt opp forrige dagpengeperiode" id periodeOppbruktManuell avhengerAv harHattDagpengerSiste13mnd,
             boolsk faktum "Sykepenger siste 36 mnd" id sykepengerSiste36mnd avhengerAv virkningsdato,
             boolsk faktum "Svangerskapsrelaterte sykepenger" id svangerskapsrelaterteSykepengerManuell avhengerAv sykepengerSiste36mnd,
-            boolsk faktum "Fangst og fisk manuell" id fangstOgFiskManuell avhengerAv fangstOgFiskInntektSiste36mnd,
             boolsk faktum "Har hatt inntekt/trygdeperioder fra EØS" id eøsArbeid avhengerAv innsendtSøknadsId,
             boolsk faktum "EØS arbeid manuell" id eøsArbeidManuell avhengerAv eøsArbeid,
             boolsk faktum "Ugyldig dato manuell" id uhåndterbartVirkningsdatoManuell avhengerAv virkningsdato,
@@ -133,7 +129,6 @@ internal object AvslagPåMinsteinntektOppsett {
             mapOf(
                 ønsketDato to "ØnskerDagpengerFraDato",
                 virkningsdato to "Virkningstidspunkt",
-                fangstOgFiskInntektSiste36mnd to "FangstOgFiskeInntektSiste36mnd",
                 inntektSiste36mnd to "InntektSiste3År",
                 inntektSiste12mnd to "InntektSiste12Mnd",
                 minsteinntektfaktor36mnd to "ØvreTerskelFaktor",

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminsteinntekt/ManuellBehandling.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminsteinntekt/ManuellBehandling.kt
@@ -6,8 +6,6 @@ import no.nav.dagpenger.model.subsumsjon.hvisOppfyltManuell
 import no.nav.dagpenger.model.subsumsjon.minstEnAv
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.eøsArbeid
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.eøsArbeidManuell
-import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.fangstOgFiskInntektSiste36mnd
-import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.fangstOgFiskManuell
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste13mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.hattLukkedeSakerSiste8Uker
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.hattLukkedeSakerSiste8UkerManuell
@@ -22,9 +20,6 @@ import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinste
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.virkningsdato
 
 internal object ManuellBehandling {
-    private val hattInntektFraFangstOgFisk = with(prototypeFakta) {
-        boolsk(fangstOgFiskInntektSiste36mnd) er true hvisOppfyltManuell (boolsk(fangstOgFiskManuell))
-    }
 
     private val harArbeidetEøs = with(prototypeFakta) {
         boolsk(eøsArbeid) er true hvisOppfyltManuell (boolsk(eøsArbeidManuell))
@@ -58,7 +53,6 @@ internal object ManuellBehandling {
         "manuelt behandles".minstEnAv(
             virkningsdatoEtterNåværendeInntektsrapporteringsperiode,
             harArbeidetEøs,
-            hattInntektFraFangstOgFisk,
             erMuligGjenopptak,
             harHattSykepenger,
             harJobbetUtenforNorge,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminsteinntekt/ManuellBehandling.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminsteinntekt/ManuellBehandling.kt
@@ -8,7 +8,7 @@ import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinste
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.eøsArbeidManuell
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.fangstOgFiskInntektSiste36mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.fangstOgFiskManuell
-import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste36mnd
+import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste13mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.hattLukkedeSakerSiste8Uker
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.hattLukkedeSakerSiste8UkerManuell
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.inntektsrapporteringsperiodeTom
@@ -43,7 +43,7 @@ internal object ManuellBehandling {
     }
 
     private val erMuligGjenopptak = with(prototypeFakta) {
-        boolsk(harHattDagpengerSiste36mnd) er true hvisOppfyltManuell (boolsk(periodeOppbruktManuell))
+        boolsk(harHattDagpengerSiste13mnd) er true hvisOppfyltManuell (boolsk(periodeOppbruktManuell))
     }
 
     private val harHattSykepenger = with(prototypeFakta) {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminsteinntekt/Seksjoner.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminsteinntekt/Seksjoner.kt
@@ -8,8 +8,6 @@ import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinste
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.behandlingsdato
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.eøsArbeid
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.eøsArbeidManuell
-import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.fangstOgFiskInntektSiste36mnd
-import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.fangstOgFiskManuell
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.grunnbeløp
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste13mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harInntektNesteKalendermåned
@@ -119,13 +117,7 @@ internal object Seksjoner {
             boolsk(hattLukkedeSakerSiste8Uker),
         )
     }
-    private val inntektshistorikk = with(prototypeFakta) {
-        Seksjon(
-            "inntektshistorikk",
-            Rolle.nav,
-            boolsk(fangstOgFiskInntektSiste36mnd),
-        )
-    }
+
     private val sykepengehistorikk = with(prototypeFakta) {
         Seksjon(
             "sykepengehistorikk",
@@ -149,16 +141,6 @@ internal object Seksjoner {
         )
     }
 
-    /*
-
-    private val godkjennSluttårsak = with(søknad) {
-        Seksjon(
-            "godkjenn sluttårsak",
-            Rolle.saksbehandler,
-            boolsk(godkjenningSluttårsak),
-        )
-    }
-     */
     private val endredeArbeidsforhold = with(prototypeFakta) {
         Seksjon(
             "arbeidsforhold",
@@ -191,13 +173,7 @@ internal object Seksjoner {
             boolsk(svangerskapsrelaterteSykepengerManuell),
         )
     }
-    private val manuellFangstOgFisk = with(prototypeFakta) {
-        Seksjon(
-            "mulige inntekter fra fangst og fisk",
-            Rolle.manuell,
-            boolsk(fangstOgFiskManuell),
-        )
-    }
+
     private val manuellEøs = with(prototypeFakta) {
         Seksjon(
             "EØS-arbeid",
@@ -280,7 +256,6 @@ internal object Seksjoner {
             arbeidsøkerPerioder,
             dagpengehistorikk,
             lukkedeSaker,
-            inntektshistorikk,
             sykepengehistorikk,
             inntekter,
             inntektNesteKalendermåned,
@@ -289,7 +264,6 @@ internal object Seksjoner {
             alder,
             manuellGjenopptak,
             manuellSykepenger,
-            manuellFangstOgFisk,
             manuellEøs,
             manuellDatoer,
             manuellOppfyllerKraveneTilMinsteArbeidsinntekt,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminsteinntekt/Seksjoner.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminsteinntekt/Seksjoner.kt
@@ -11,7 +11,7 @@ import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinste
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.fangstOgFiskInntektSiste36mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.fangstOgFiskManuell
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.grunnbeløp
-import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste36mnd
+import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste13mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harInntektNesteKalendermåned
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.hattLukkedeSakerSiste8Uker
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.hattLukkedeSakerSiste8UkerManuell
@@ -109,7 +109,7 @@ internal object Seksjoner {
         Seksjon(
             "dagpengehistorikk",
             Rolle.nav,
-            boolsk(harHattDagpengerSiste36mnd),
+            boolsk(harHattDagpengerSiste13mnd),
         )
     }
     private val lukkedeSaker = with(prototypeFakta) {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/integration/AvslagPåMinsteinntektTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/integration/AvslagPåMinsteinntektTest.kt
@@ -13,7 +13,6 @@ import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinste
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.antallEndredeArbeidsforhold
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.behandlingsdato
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.eøsArbeid
-import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.fangstOgFiskInntektSiste36mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.grunnbeløp
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste13mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harInntektNesteKalendermåned
@@ -121,7 +120,6 @@ internal class AvslagPåMinsteinntektTest : SøknadBesvarer() {
             assertGjeldendeSeksjon("datafrasøknad")
             besvar(eøsArbeid, false)
             besvar(jobbetUtenforNorge, false)
-            besvar(fangstOgFiskInntektSiste36mnd, false)
             besvar(verneplikt, false)
             besvar(ønsketDato, 5.januar)
             besvar(harInntektNesteKalendermåned, false)
@@ -135,9 +133,6 @@ internal class AvslagPåMinsteinntektTest : SøknadBesvarer() {
 
             assertGjeldendeSeksjon("inntektsrapporteringsperioder")
             besvar(inntektsrapporteringsperiodeTom, 10.januar)
-
-            assertGjeldendeSeksjon("inntektshistorikk")
-            besvar(fangstOgFiskInntektSiste36mnd, false)
 
             assertGjeldendeSeksjon("dagpengehistorikk")
             besvar(harHattDagpengerSiste13mnd, false)

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/integration/AvslagPåMinsteinntektTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/integration/AvslagPåMinsteinntektTest.kt
@@ -15,7 +15,7 @@ import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinste
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.eøsArbeid
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.fangstOgFiskInntektSiste36mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.grunnbeløp
-import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste36mnd
+import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste13mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harInntektNesteKalendermåned
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.hattLukkedeSakerSiste8Uker
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.helseTilAlleTyperJobb
@@ -140,7 +140,7 @@ internal class AvslagPåMinsteinntektTest : SøknadBesvarer() {
             besvar(fangstOgFiskInntektSiste36mnd, false)
 
             assertGjeldendeSeksjon("dagpengehistorikk")
-            besvar(harHattDagpengerSiste36mnd, false)
+            besvar(harHattDagpengerSiste13mnd, false)
             besvar(hattLukkedeSakerSiste8Uker, false)
 
             assertGjeldendeSeksjon("sykepengehistorikk")

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminstinntekt/AvslagPåMinsteinntektTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminstinntekt/AvslagPåMinsteinntektTest.kt
@@ -15,7 +15,7 @@ import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinste
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.eøsArbeid
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.fangstOgFiskInntektSiste36mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.grunnbeløp
-import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste36mnd
+import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste13mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harInntektNesteKalendermåned
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.hattLukkedeSakerSiste8Uker
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.helseTilAlleTyperJobb
@@ -79,7 +79,7 @@ internal class AvslagPåMinsteinntektTest {
                 dato("$registrertArbeidssøkerPeriodeFom.1").besvar(1.januar(2018))
                 dato("$registrertArbeidssøkerPeriodeTom.1").besvar(30.januar(2018))
 
-                boolsk(harHattDagpengerSiste36mnd).besvar(false)
+                boolsk(harHattDagpengerSiste13mnd).besvar(false)
                 boolsk(hattLukkedeSakerSiste8Uker).besvar(false)
                 boolsk(sykepengerSiste36mnd).besvar(false)
 
@@ -125,7 +125,7 @@ internal class AvslagPåMinsteinntektTest {
 
     @Test
     fun `Søknader fra brukere som har hatt dagpenger de siste 36 månedene blir ikke behandlet`() {
-        manglerInntekt.boolsk(harHattDagpengerSiste36mnd).besvar(true)
+        manglerInntekt.boolsk(harHattDagpengerSiste13mnd).besvar(true)
         assertNesteSeksjon("mulig gjenopptak")
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminstinntekt/AvslagPåMinsteinntektTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/quiz/mediator/soknad/avslagminstinntekt/AvslagPåMinsteinntektTest.kt
@@ -13,7 +13,6 @@ import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinste
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.arenaFagsakId
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.behandlingsdato
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.eøsArbeid
-import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.fangstOgFiskInntektSiste36mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.grunnbeløp
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harHattDagpengerSiste13mnd
 import no.nav.dagpenger.quiz.mediator.soknad.avslagminsteinntekt.AvslagPåMinsteinntektOppsett.harInntektNesteKalendermåned
@@ -87,8 +86,6 @@ internal class AvslagPåMinsteinntektTest {
                 boolsk(eøsArbeid).besvar(false)
                 boolsk(jobbetUtenforNorge).besvar(false)
 
-                boolsk(fangstOgFiskInntektSiste36mnd).besvar(false)
-
                 inntekt(grunnbeløp).besvar(100000.årlig)
                 desimaltall(minsteinntektfaktor12mnd).besvar(1.5)
                 desimaltall(minsteinntektfaktor36mnd).besvar(3.0)
@@ -158,12 +155,6 @@ internal class AvslagPåMinsteinntektTest {
     fun `Skal manuelt behandles hvis har sykepenger`() {
         manglerInntekt.boolsk(sykepengerSiste36mnd).besvar(true)
         assertNesteSeksjon("svangerskapsrelaterte sykepenger")
-    }
-
-    @Test
-    fun `Fangst og fisk skal manuelt behandles`() {
-        manglerInntekt.boolsk(fangstOgFiskInntektSiste36mnd).besvar(true)
-        assertNesteSeksjon("mulige inntekter fra fangst og fisk")
     }
 
     @Test


### PR DESCRIPTION
Endret fra 36 til 13 måneders sjekk av når en hadde en aktiv arena sak. Egentlig hadde jeg lyst til å legge til 13 måneders sjekk men det er så mye ting ekstra som må gjøres da. Ref at quiz og avslag på minsteinntekt sjekker ikke skal leve der lenge tok jeg en letter vei til mål. 

13 måneder behovet er implementert her https://github.com/navikt/dp-oppslag-vedtak/commit/7dde9c33f030512e1b83d3cb1c6973d9fd0b1359 